### PR TITLE
Fix processing order of header rewriting

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,13 +61,13 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 	dump, _ := httputil.DumpRequest(r, true)
 	fmt.Println(string(dump))
 
-	w.WriteHeader(res.Status)
 	for k, v := range res.Header {
 		w.Header().Set(k, v)
 	}
 	if res.NoContent {
 		return
 	}
+	w.WriteHeader(res.Status)
 	resBody, _ := json.Marshal(res.Body)
 	w.Write(resBody)
 }


### PR DESCRIPTION
HTTP header rewriting needs to be processed in the following order.

1. header
2. status code
3. response body

Reference: https://pod.hatenablog.com/entry/2019/01/26/150921